### PR TITLE
Add depends_on in xkf_governance_global

### DIFF
--- a/azure/governance/main.tf
+++ b/azure/governance/main.tf
@@ -48,7 +48,10 @@ module "governance_regional" {
 }
 
 module "xkf_governance_global" {
-  source            = "github.com/xenitab/terraform-modules//modules/azure/xkf-governance-global?ref=2022.11.2"
+  source = "github.com/xenitab/terraform-modules//modules/azure/xkf-governance-global?ref=2022.11.2"
+  depends_on = [
+    module.governance_regional
+  ]
   cloud_provider    = "azure"
   environment       = var.environment
   subscription_name = var.subscription_name


### PR DESCRIPTION
Without it the data resource in xkf_governance_global is unable to find the contirbutor group when a new common_name is defined tenant_resource_group_configs

An example of the error

```
│ Error: No group found matching specified filter (displayName eq 'az-rg-test-prod-example-owner')
│
│   with module.xkf_governance_global.data.azuread_group.resource_group_owner["example"],
│   on .terraform/modules/xkf_governance_global/modules/azure/xkf-governance-global/delegate-xks-rg.tf line 8, in data "azuread_group" "resource_group_owner":
│    8:   display_name = "${var.azure_ad_group_prefix}${var.group_name_separator}rg${var.group_name_separator}${var.subscription_name}${var.group_name_separator}${var.environment}${var.group_name_separator}${each.key}${var.group_name_separator}owner"
│
```
