### PR TITLE
Make it possible to disable promtail/prometheus

### DIFF
--- a/aws/aws-eks/eks1.tf
+++ b/aws/aws-eks/eks1.tf
@@ -90,7 +90,7 @@ module "eks1_core" {
     azure_ad_app          = module.eks_global.azad_kube_proxy.azure_ad_app
   }
 
-  falco_enabled = true
+  falco_enabled      = true
   prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     role_arn                        = module.eks1.prometheus_config.role_arn

--- a/aws/aws-eks/eks1.tf
+++ b/aws/aws-eks/eks1.tf
@@ -90,7 +90,8 @@ module "eks1_core" {
     azure_ad_app          = module.eks_global.azad_kube_proxy.azure_ad_app
   }
 
-  falco_enabled      = true
+  falco_enabled = true
+
   prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     role_arn                        = module.eks1.prometheus_config.role_arn

--- a/aws/aws-eks/eks1.tf
+++ b/aws/aws-eks/eks1.tf
@@ -91,8 +91,7 @@ module "eks1_core" {
   }
 
   falco_enabled = true
-
-  prometheus_enabled = true
+  prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     role_arn                        = module.eks1.prometheus_config.role_arn
     tenant_id                       = var.tenant_id
@@ -110,7 +109,7 @@ module "eks1_core" {
   starboard_config  = module.eks1.starboard_config
   starboard_enabled = true
 
-  promtail_enabled = true
+  promtail_enabled = var.promtail_enabled
   promtail_config = {
     role_arn            = module.eks1.promtail_config.role_arn
     loki_address        = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"

--- a/aws/aws-eks/eks2.tf
+++ b/aws/aws-eks/eks2.tf
@@ -92,7 +92,7 @@ module "eks2_core" {
 
   falco_enabled = true
 
-  prometheus_enabled = true
+  prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     role_arn                        = module.eks2.prometheus_config.role_arn
     tenant_id                       = var.tenant_id
@@ -110,7 +110,7 @@ module "eks2_core" {
   starboard_config  = module.eks2.starboard_config
   starboard_enabled = true
 
-  promtail_enabled = true
+  promtail_enabled = var.promtail_enabled
   promtail_config = {
     role_arn            = module.eks2.promtail_config.role_arn
     loki_address        = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"

--- a/aws/aws-eks/variables.tf
+++ b/aws/aws-eks/variables.tf
@@ -123,6 +123,12 @@ variable "ingress_config" {
   }
 }
 
+variable "prometheus_enabled" {
+  description = "Should prometheus be enabled"
+  type        = bool
+  default     = true
+}
+
 variable "prometheus_config" {
   description = "Configuration for prometheus"
   type = object({
@@ -139,4 +145,10 @@ variable "prometheus_config" {
     resource_selector          = ["platform"]
     volume_claim_size          = "5Gi"
   }
+}
+
+variable "promtail_enabled" {
+  description = "Should promtail be enabled"
+  type        = bool
+  default     = true
 }

--- a/azure/aks/aks1.tf
+++ b/azure/aks/aks1.tf
@@ -107,7 +107,7 @@ module "aks1_core" {
 
   node_local_dns_enabled = true
 
-  prometheus_enabled = true
+  prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     tenant_id                       = var.tenant_id
     remote_write_authenticated      = var.prometheus_config.remote_write_authenticated
@@ -120,7 +120,7 @@ module "aks1_core" {
     identity                        = module.aks_regional.xenit.identity
   }
 
-  promtail_enabled = true
+  promtail_enabled = promtail_enabled
   promtail_config = {
     loki_address         = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"
     azure_key_vault_name = module.aks_regional.xenit.azure_key_vault_name

--- a/azure/aks/aks1.tf
+++ b/azure/aks/aks1.tf
@@ -120,7 +120,7 @@ module "aks1_core" {
     identity                        = module.aks_regional.xenit.identity
   }
 
-  promtail_enabled = promtail_enabled
+  promtail_enabled = var.promtail_enabled
   promtail_config = {
     loki_address         = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"
     azure_key_vault_name = module.aks_regional.xenit.azure_key_vault_name

--- a/azure/aks/aks2.tf
+++ b/azure/aks/aks2.tf
@@ -120,7 +120,7 @@ module "aks2_core" {
     identity                        = module.aks_regional.xenit.identity
   }
 
-  promtail_enabled = promtail_enabled
+  promtail_enabled = var.promtail_enabled
   promtail_config = {
     loki_address         = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"
     azure_key_vault_name = module.aks_regional.xenit.azure_key_vault_name

--- a/azure/aks/aks2.tf
+++ b/azure/aks/aks2.tf
@@ -107,7 +107,7 @@ module "aks2_core" {
 
   node_local_dns_enabled = true
 
-  prometheus_enabled = true
+  prometheus_enabled = var.prometheus_enabled
   prometheus_config = {
     tenant_id                       = var.tenant_id
     remote_write_authenticated      = var.prometheus_config.remote_write_authenticated
@@ -120,7 +120,7 @@ module "aks2_core" {
     identity                        = module.aks_regional.xenit.identity
   }
 
-  promtail_enabled = true
+  promtail_enabled = promtail_enabled
   promtail_config = {
     loki_address         = "https://logging.prod.unbox.xenit.io/loki/api/v1/push"
     azure_key_vault_name = module.aks_regional.xenit.azure_key_vault_name

--- a/azure/aks/variables.tf
+++ b/azure/aks/variables.tf
@@ -139,6 +139,12 @@ variable "ingress_config" {
   }
 }
 
+variable "prometheus_enabled" {
+  description = "Should prometheus be enabled"
+  type        = bool
+  default     = true
+}
+
 variable "prometheus_config" {
   description = "Configuration for prometheus"
   type = object({
@@ -177,6 +183,12 @@ variable "control_plane_logs_enabled" {
 
 variable "kubernetes_network_policy_default_deny" {
   description = "If network policies should by default deny cross namespace traffic"
+  type        = bool
+  default     = true
+}
+
+variable "promtail_enabled" {
+  description = "Should promtail be enabled"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
When we run tests, we don't always want to use monitoring but I still want to be able to use the template.
